### PR TITLE
Patch help link

### DIFF
--- a/help-link.patch
+++ b/help-link.patch
@@ -1,0 +1,13 @@
+diff --git a/src/ui/TodoPage.qml b/src/ui/TodoPage.qml
+index 0783d66..795dbc1 100644
+--- a/src/ui/TodoPage.qml
++++ b/src/ui/TodoPage.qml
+@@ -261,7 +261,7 @@ Kirigami.ScrollablePage {
+         Kirigami.Action {
+             text: i18nc("@action:inmenu", "Help…")
+             icon.name: "help-contents-symbolic"
+-            onTriggered: Qt.openUrlExternally("help:/komodo")
++            onTriggered: Qt.openUrlExternally("https://invent.kde.org/utilities/komodo/-/blob/master/DOCUMENTATION.md")
+             enabled: pageStack.layers.depth <= 1
+             shortcut: StandardKey.HelpContents
+         },

--- a/org.kde.komodo.json
+++ b/org.kde.komodo.json
@@ -77,6 +77,10 @@
                 {
                     "type": "patch",
                     "path": "remove-filetype-filters.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "help-link.patch"
                 }
             ]
         }


### PR DESCRIPTION
The help link may or may not work, depending if KHelpCenter is installed. If not, it can't redirect to the correct documentation page since docs.kde.org does not have KomoDo in there.

Instead just always redirect to the documentation file on Gitlab.