### PR TITLE
Update KDE runtime to 6.10

### DIFF
--- a/org.kde.komodo.json
+++ b/org.kde.komodo.json
@@ -1,7 +1,7 @@
 {
     "id": "org.kde.komodo",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.9",
+    "runtime-version": "6.10",
     "sdk": "org.kde.Sdk",
     "command": "komodo",
     "finish-args": [
@@ -27,26 +27,6 @@
         "/share/pkgconfig"
     ],
     "modules": [
-        {
-            "name": "kirigamiaddons",
-            "config-opts": [
-                "-DBUILD_TESTING=OFF"
-            ],
-            "buildsystem": "cmake-ninja",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-1.10.0.tar.xz",
-                    "sha256": "c98f92bf7c452e12f6dc403404215413db3959fe904ad830ead0db6bb09b3d11",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 242933,
-                        "stable-only": true,
-                        "url-template": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-$version.tar.xz"
-                    }
-                }
-            ]
-        },
         {
             "name": "komodo",
             "buildsystem": "cmake-ninja",


### PR DESCRIPTION
Also remove the custom build of Kirigami Addons, which is already included in the runtime.